### PR TITLE
C# - Simplify the public API

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -5,8 +5,6 @@ namespace Centroid.Tests
     [TestFixture]
     public class ConfigTest
     {
-        private const string SharedFilePath = @"..\..\..\..\config.json";
-
         private const string JsonConfig = @"
             {
                 ""Dev"": {
@@ -28,13 +26,6 @@ namespace Centroid.Tests
         ";
 
         [Test]
-        public void environment_property_shows_correct_environment()
-        {
-            var config = new Config(JsonConfig).WithEnvironment("Prod");
-            Assert.AreEqual("Prod", config.Environment);
-        }
-
-        [Test]
         public void environment_specific_config_is_included_correctly()
         {
             var config = new Config(JsonConfig).WithEnvironment("Dev");
@@ -53,16 +44,6 @@ namespace Centroid.Tests
         {
             dynamic config = new Config(@"{ ""snake_key"": ""some value"" }");
             Assert.AreEqual("some value", config.SnakeKey);
-        }
-
-        [Test]
-        public void can_load_config_from_file()
-        {
-            Assert.DoesNotThrow(() =>
-                {
-                    dynamic config = Config.FromFile(SharedFilePath);
-                    Assert.NotNull(config.All);
-                });
         }
     }
 }

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -10,23 +10,14 @@ namespace Centroid
     {
         public dynamic RawConfig { get; private set; }
 
-        public string Environment { get; private set; }
-
         public Config(string json)
         {
             RawConfig = JObject.Parse(json);
         }
 
-        public Config(dynamic config, string env)
+        protected Config(dynamic config)
         {
             RawConfig = config;
-            Environment = env;
-        }
-
-        public static Config FromFile(string fileName)
-        {
-            string json = System.IO.File.ReadAllText(fileName);
-            return new Config(json);
         }
 
         public dynamic WithEnvironment(string environment)
@@ -39,7 +30,7 @@ namespace Centroid
                 envConfig[cfg.Name] = cfg.Value;
             }
 
-            return new Config(envConfig, environment);
+            return new Config(envConfig);
         }
 
         public override bool TryGetMember(GetMemberBinder binder, out object result)
@@ -50,7 +41,7 @@ namespace Centroid
 
                 if (container is JContainer)
                 {
-                    result = new Config(container, Environment);
+                    result = new Config(container);
                 }
                 else
                 {


### PR DESCRIPTION
This is a test of how things would look with a simpler public interface. It removes the `FromFile` convenience method, and just leaves the constructor that takes raw JSON. It also removes the `Environment` property, with the idea that if the calling code sets up the config with an environment, then it already knows the environment and there's no need for Centroid to track it.

Anyone have thoughts?
