### PR TITLE
Make config file path in tests cross platform

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -1,11 +1,12 @@
 ﻿using NUnit.Framework;
+using System.IO;
 
 namespace Centroid.Tests
 {
     [TestFixture]
     public class ConfigTest
     {
-        private const string SharedFilePath = @"..\..\..\..\config.json";
+        private readonly string sharedFilePath;
 
         private const string JsonConfig = @"
             {
@@ -26,6 +27,11 @@ namespace Centroid.Tests
                 }
             }
         ";
+
+        public ConfigTest()
+        {
+            sharedFilePath = Path.Combine("..", "..", "..", "..", "config.json");
+        }
 
         [Test]
         public void environment_property_shows_correct_environment()
@@ -60,7 +66,7 @@ namespace Centroid.Tests
         {
             Assert.DoesNotThrow(() =>
                 {
-                    dynamic config = Config.FromFile(SharedFilePath);
+                    dynamic config = Config.FromFile(sharedFilePath);
                     Assert.NotNull(config.All);
                 });
         }


### PR DESCRIPTION
Updated the existing test to use Path.Combine for building the path to the config file, since as written it failed on OS X.
