### PR TITLE
Make APIs match

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -1,35 +1,16 @@
 ﻿using NUnit.Framework;
 using System.IO;
+using System;
+using System.Text.RegularExpressions;
 
 namespace Centroid.Tests
 {
     [TestFixture]
     public class ConfigTest
     {
-        private readonly string sharedFilePath;
+        private const string JsonConfig = @"{""Environment"": {""TheKey"": ""TheValue""}}";
 
-        private const string JsonConfig = @"
-            {
-                ""Dev"": {
-                    ""Database"": {
-                        ""Server"": ""the-dev-database""
-                    }
-                },
-                ""Prod"": {
-                    ""Database"": {
-                        ""Server"": ""the-prod-database""
-                    },
-                    ""SharedNest"": {
-                        ""SharedKey"": ""prod value""
-                    }
-                },
-                ""All"": {
-                    ""SharedNest"": {
-                        ""SharedKey"": ""shared value""
-                    }
-                }
-            }
-        ";
+        private readonly string sharedFilePath;
 
         public ConfigTest()
         {
@@ -37,48 +18,83 @@ namespace Centroid.Tests
         }
 
         [Test]
-        public void environment_property_shows_correct_environment()
+        public void test_create_from_string()
         {
-            var config = new Config(JsonConfig).WithEnvironment("Prod");
-            Assert.AreEqual("Prod", config.Environment);
+            dynamic config = new Config(JsonConfig);
+            Assert.That(config.Environment.TheKey, Is.EqualTo("TheValue"));
         }
 
         [Test]
-        public void environment_specific_config_is_included_correctly()
+        public void test_create_from_file()
         {
-            var config = new Config(JsonConfig).WithEnvironment("Dev");
-            Assert.AreEqual("the-dev-database", config.Database.Server);
+            dynamic config = Config.FromFile(sharedFilePath);
+            Assert.That(config.Dev.Database.Server, Is.EqualTo("sqldev01.centroid.local"));
         }
 
         [Test]
-        public void shared_config_is_included_correctly()
+        public void test_raises_if_key_not_found()
         {
-            var config = new Config(JsonConfig).WithEnvironment("Dev");
-            Assert.AreEqual("shared value", config.SharedNest.SharedKey);
+            dynamic config = new Config(JsonConfig);
+            Assert.Throws(Is.InstanceOf<Exception>(), delegate { var doesNotExist = config.DoesNotExist; });
         }
 
         [Test]
-        public void pascal_case_can_be_used_with_snake_cased_json()
+        public void test_readable_using_snake_case_property()
         {
-            dynamic config = new Config(@"{ ""snake_key"": ""some value"" }");
-            Assert.AreEqual("some value", config.SnakeKey);
+            dynamic config = new Config(JsonConfig);
+            Assert.That(config.environment.the_key, Is.EqualTo("TheValue"));
         }
 
         [Test]
-        public void can_load_config_from_file()
+        public void test_environment_specific_config_is_included()
         {
-            Assert.DoesNotThrow(() =>
-                {
-                    dynamic config = Config.FromFile(sharedFilePath);
-                    Assert.NotNull(config.All);
-                });
+            var config = new Config(JsonConfig);
+            dynamic environmentConfig = config.ForEnvironment("Environment");
+            Assert.That(environmentConfig.TheKey, Is.EqualTo("TheValue"));
         }
 
         [Test]
-        public void environment_specific_config_overrides_all()
+        public void test_shared_config_is_included()
         {
-            dynamic config = new Config(JsonConfig).WithEnvironment("Prod");
-            Assert.AreEqual("prod value", config.SharedNest.SharedKey);
+            var config = Config.FromFile(sharedFilePath);
+            dynamic environmentConfig = config.ForEnvironment("Dev");
+            Assert.That(environmentConfig.CI.Repo, Is.EqualTo(@"https://github.com/ResourceDataInc/Centroid"));
+        }
+
+        [Test]
+        public void test_to_string_returns_json()
+        {
+            var config = new Config(JsonConfig);
+            var configMinusWhitespace = Regex.Replace(JsonConfig, @"\s+", "");
+            Assert.That(config.ToString(), Is.EqualTo(configMinusWhitespace));
+        }
+
+        [Test]
+        public void test_iterating_raw_config()
+        {
+            dynamic config = Config.FromFile(sharedFilePath);
+            var keyCount = 0;
+            foreach (var key in config.RawConfig)
+            {
+                keyCount++;
+            }
+            Assert.That(keyCount, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void test_modifying_raw_config()
+        {
+            dynamic config = new Config(JsonConfig);
+            config.RawConfig["Environment"]["TheKey"] = "NotTheValue"; 
+            Assert.That(config.Environment.TheKey, Is.EqualTo("NotTheValue"));
+        }
+
+        [Test]
+        public void test_environment_specific_config_overrides_all()
+        {
+            var config = new Config(@"{""Prod"": {""Shared"": ""production!""}, ""All"": {""Shared"": ""none""}}");
+            dynamic environmentConfig = config.ForEnvironment("Prod");
+            Assert.That(environmentConfig.Shared, Is.EqualTo("production!"));
         }
     }
 }

--- a/python/centroid.py
+++ b/python/centroid.py
@@ -1,55 +1,47 @@
 import json
 
 class Config:
-    def __init__(self, config, env = None):
-        if env is not None:
-            self.environment = env
-
+    def __init__(self, config):
         if type(config) is dict:
-            self.config = config
+            self.raw_config = config
         else:
-            self.config = json.loads(config)
+            self.raw_config = json.loads(config)
 
     def __getattr__(self, attrib):
         return self[attrib]
 
     # config['key']
     def __getitem__(self, key):
-        key = _get_actual_key(key, self.config)
+        key = _get_actual_key(key, self.raw_config)
         if key is None:
             raise Exception('Key not found in collection.')
 
-        value = _get_value(key, self.config)
+        value = _get_value(key, self.raw_config)
         if type(value) is dict:
             return Config(value)
         return value
 
     # to string
     def __str__(self):
-        return str(json.dumps(self.config))
+        return str(json.dumps(self.raw_config))
 
-    def environment(self, env):
-        env_json = self.config[env]
+    def for_environment(self, env):
+        env_json = self.raw_config[env]
 
-        actual_key = _get_actual_key('all', self.config)
+        actual_key = _get_actual_key('all', self.raw_config)
         if actual_key is None:
-            return Config(env_json, env)
+            return Config(env_json)
 
-        all_json = _get_value(actual_key, self.config)
+        all_json = _get_value(actual_key, self.raw_config)
         all_json.update(env_json);
 
-        return Config(all_json, env)
+        return Config(all_json)
 
     @staticmethod
     def from_file(filename):
         with open(filename) as json_file:
             str_json = json_file.read()
             return Config(str_json)
-
-    @staticmethod
-    def from_action(action):
-        str_json = action()
-        return Config(str_json)
 
 # case insensitive hashtable helpers
 def _get_normalised_key(unnormalisedKey):


### PR DESCRIPTION
Python changes
- Nuke `from_action`
- Change `environment()` to `for_environment`
- Remove `environment` property
- Add tests for `raw_config` property

C# changes
- Rename `WithEnvironment()` to `ForEnvironment()`
- Nuke `Environment` property
- Change tests to match the python tests
- Fix bug that assumed there is always an `All` config entry
- Add tests for `RawConfig` property

Tasks
- [x] Make the set of tests for python and c# compatible, i.e. test for the same things.
- [x] Squash commits

This will fix #13.
