### PR TITLE
Publish .NET package to NuGet

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,15 @@ namespace :package do
   end
 end
 
+namespace :release do
+  desc "Release .NET package"
+  task :cs  => ["package:cs"] do
+    Dir.glob("dot-net/build/pkg/*.nupkg") do |f|
+      system "dot-net/build/support/NuGet.exe", ["push", f], :clr_command => true
+    end
+  end
+end
+
 namespace :test do
   desc "Test .NET"
   test_runner :cs => [:build] do |cmd|


### PR DESCRIPTION
Requires that you specify the api key using `nuget setapikey THE-KEY` beforehand (one time). 

You can't push a package/version combo that already exists, and if you try to do so, it'll error. I didn't bother to try to rescue the error here--if someone thinks that's important, speak up, but otherwise I'm inclined to just let the task fail.

Because NuGet requires Mono when running on non-Windows platforms and this is a cross platform task, I'm using Albacore's `system` method to shell out, which handles whether or not to run the command with Mono. Tested that on both my Mac and Windows machines--seemed to work ok.
