### PR TITLE
Fix compiler warning in .NET test

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -37,7 +37,7 @@ namespace Centroid.Tests
         public void test_raises_if_key_not_found()
         {
             dynamic config = new Config(JsonConfig);
-            Assert.Throws(Is.InstanceOf<Exception>(), delegate { var doesNotExist = config.DoesNotExist; });
+            Assert.Throws(Is.InstanceOf<Exception>(), () => Console.Write(config.DoesNotExist));
         }
 
         [Test]


### PR DESCRIPTION
Removes unused variable in a test assertion that was causing a compiler warning on Mono. ReSharper didn't like it either.
