### PR TITLE
Disable Travis emails [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ before_install:
 
 script:
  - rake test
+
+notifications:
+  email: false


### PR DESCRIPTION
The GitHub PR integration should be good enough to inform interested parties of failed builds.
