### PR TITLE
Use version 0.1.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ namespace :package do
       m.summary = "A centralized paradigm to configuration management."
       m.description = "Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties."
       m.authors = "Resource Data, Inc."
-      m.version = "1.0.0"
+      m.version = "0.1.0"
       m.license_url = "https://github.com/ResourceDataInc/Centroid/blob/master/LICENSE.txt"
       m.project_url = "https://github.com/ResourceDataInc/Centroid"
     end

--- a/dot-net/Centroid/Properties/AssemblyInfo.cs
+++ b/dot-net/Centroid/Properties/AssemblyInfo.cs
@@ -31,5 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.1.0")]

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name = 'centroid',
-      version = '1.0.0',
+      version = '0.1.0',
       description = 'A centralized paradigm to configuration management.',
       long_description = 'Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties.',
       author = 'Resource Data, Inc',


### PR DESCRIPTION
From Campfire:

> **Greg S.**: My official opinion v2, I think we should merge the PRs we have now and then release as 0.1.0 rather than 1.0.0. I think we want to have the API nailed before we call it 1.0.0 since an API change at that point would require going to 2.*.
> That will let us start playing with it and testing out some of these use case ideas.
> 
> **Chris T.:** :+1:
> 
> **Jason R.:** :+1: for v0.1.0

This ignores the problem of manually having to bump version numbers.
