### PR TITLE
Move back to v1.0.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ namespace :package do
       m.summary = "A centralized paradigm to configuration management."
       m.description = "Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties."
       m.authors = "Resource Data, Inc."
-      m.version = "0.1.0"
+      m.version = "1.0.1"
       m.license_url = "https://github.com/ResourceDataInc/Centroid/blob/master/LICENSE.txt"
       m.project_url = "https://github.com/ResourceDataInc/Centroid"
     end

--- a/dot-net/Centroid/Properties/AssemblyInfo.cs
+++ b/dot-net/Centroid/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0")]
+[assembly: AssemblyVersion("1.0.1")]

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name = 'centroid',
-      version = '0.1.0',
+      version = '1.0.0',
       description = 'A centralized paradigm to configuration management.',
       long_description = 'Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties.',
       author = 'Resource Data, Inc',

--- a/ruby/centroid.gemspec
+++ b/ruby/centroid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'centroid'
-  s.version = '0.1.1'
+  s.version = '1.0.0'
   s.summary = 'A centralizaed paradigm to configuration management.'
   s.description = 'Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties.'
   s.author = 'Resource Data, Inc'


### PR DESCRIPTION
The NuGet release process was tested with v1.0.0, so we decided to just stick to 1.x major version. Since the published package is behind on features, we'll start NuGet at 1.0.1.
