### PR TITLE
Clean the nuget package directory before packaging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ namespace :package do
   directory "dot-net/build/pkg"
   desc "Package .NET"
   nugets_pack :cs => ["dot-net/build/pkg", :test] do |cmd|
+    FileList["dot-net/build/pkg/*.nupkg"].each {|f| File.delete(f) }
     cmd.exe = "dot-net/build/support/NuGet.exe"
     cmd.out = "dot-net/build/pkg"
     cmd.files = ["dot-net/Centroid/Centroid.csproj"]


### PR DESCRIPTION
Without this, old versions of nupkg files in the pkg directory can be published accidentally.
