### PR TITLE
Ensure that the special 'all' environment is not case sensitive

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -142,5 +142,17 @@ namespace Centroid.Tests
             }
             Assert.That(itemCount, Is.EqualTo(1));
         }
+
+        [Test]
+        public void test_all_environment_is_not_case_sensitive()
+        {
+            var upperCaseAllConfig = new Config(@"{""Prod"": {""Shared"": ""production!""}, ""All"": {""Shared"": ""none"", ""AllOnly"": ""works""}}");
+            var upperCaseAllEnvironmentConfig = upperCaseAllConfig.ForEnvironment("Prod");
+            Assert.That(upperCaseAllEnvironmentConfig.AllOnly, Is.EqualTo("works"));
+
+            var lowerCaseAllConfig = new Config(@"{""Prod"": {""Shared"": ""production!""}, ""all"": {""Shared"": ""none"", ""AllOnly"": ""works""}}");
+            var lowerCaseAllEnvironmentConfig = lowerCaseAllConfig.ForEnvironment("Prod");
+            Assert.That(lowerCaseAllEnvironmentConfig.AllOnly, Is.EqualTo("works"));
+        }
     }
 }

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -37,8 +37,8 @@ namespace Centroid
 
         public dynamic ForEnvironment(string environment)
         {
-            var envConfig = RawConfig[environment];
-            var allConfig = RawConfig.All;
+            var envConfig = GetContainer(environment);
+            var allConfig = GetContainer("all");
 
             if (allConfig == null)
             {
@@ -123,14 +123,19 @@ namespace Centroid
 
         dynamic GetValue(string key)
         {
-            var actualKey = GetActualKey(key);
-            var container = RawConfig[actualKey];
+            var container = GetContainer(key);
             return GetValueFromContainer(container);
+        }
+
+        dynamic GetContainer(string key)
+        {
+            var actualKey = GetActualKey(key);
+            return actualKey == null ? null : RawConfig[actualKey];
         }
 
         string GetActualKey(string key)
         {
-            return GetDynamicMemberNames().Single(m => NormaliseKey(m) == NormaliseKey(key));
+            return GetDynamicMemberNames().SingleOrDefault(m => NormaliseKey(m) == NormaliseKey(key));
         }
 
         void ValidateUniqueKeys()

--- a/python/tests.py
+++ b/python/tests.py
@@ -88,3 +88,12 @@ class ConfigTest(unittest.TestCase):
         for item in config:
             itemCount += 1
         self.assertEqual(itemCount, 1)
+
+    def test_all_environment_is_not_case_sensitive(self):
+        config = Config('{"Prod": {"Shared": "production!"}, "All": {"Shared": "none", "AllOnly": "works"}}')
+        config = config.for_environment("Prod")
+        self.assertEqual(config.all_only, "works")
+
+        config = Config('{"Prod": {"Shared": "production!"}, "all": {"Shared": "none", "AllOnly": "works"}}')
+        config = config.for_environment("Prod")
+        self.assertEqual(config.all_only, "works")

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -84,4 +84,14 @@ class ConfigTests < Test::Unit::TestCase
     config = config.for_environment("Prod")
     assert_equal(config.shared, "production!")
   end
+
+  def test_all_environment_is_not_case_sensitive
+    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "All": {"Shared": "none", "AllOnly": "works"}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.all_only, "works")
+
+    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "all": {"Shared": "none", "AllOnly": "works"}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.all_only, "works")
+  end
 end


### PR DESCRIPTION
Add tests for case sensitive 'all' environment check in all
languages, but it's only an issue with .NET implementation.
