### PR TITLE
Bump to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next Release
+# 1.1.0 - 2014/08/22
 
 ## CSharp
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ namespace :package do
       m.summary = "A centralized paradigm to configuration management."
       m.description = "Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties."
       m.authors = "Resource Data, Inc."
-      m.version = "1.1.0-alpha3"
+      m.version = "1.1.0"
       m.license_url = "https://github.com/ResourceDataInc/Centroid/blob/master/LICENSE.txt"
       m.project_url = "https://github.com/ResourceDataInc/Centroid"
     end

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name = 'centroid',
-      version = '1.1.0-alpha3',
+      version = '1.1.0',
       description = 'A centralized paradigm to configuration management.',
       long_description = 'Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties.',
       author = 'Resource Data, Inc',

--- a/ruby/centroid.gemspec
+++ b/ruby/centroid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'centroid'
-  s.version = '1.1.0-alpha3'
+  s.version = '1.1.0'
   s.summary = 'A centralizaed paradigm to configuration management.'
   s.description = 'Centroid is a tool for loading configuration values declared in JSON, and accessing those configuration values using object properties.'
   s.author = 'Resource Data, Inc'


### PR DESCRIPTION
All issues under the [1.1 milestone](https://github.com/ResourceDataInc/Centroid/milestones/1.1) have been addressed, so it seems we're ready for a release.
