### PR TITLE
Improve property casting

### DIFF
--- a/dot-net/Centroid.Tests/Centroid.Tests.csproj
+++ b/dot-net/Centroid.Tests/Centroid.Tests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Centroid.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
- </PropertyGroup>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -47,6 +47,9 @@
       <Project>{bb414384-cd9b-42dc-93b7-8582887ce2f1}</Project>
       <Name>Centroid</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -215,5 +215,48 @@ namespace Centroid.Tests
             Assert.That(config.ContainsKey("theEnvironment"), Is.True);
             Assert.That(config.ContainsKey("DoesNotExist"), Is.False);
         }
+
+        [Test]
+        public void test_casts_to_complex_type()
+        {
+            const string json = @"
+                {
+                    ""castingObject"": {
+                        ""castingString"": ""true"",
+                        ""castingBoolean"": true,
+                        ""castingInteger"": 42
+                    }
+                }";
+
+            dynamic config = new Config(json);
+            CastingObject castingObject = config.castingObject;
+            Assert.That(castingObject, Is.InstanceOf<CastingObject>());
+        }
+
+        class CastingObject
+        {
+            public string CastingString { get; set; }
+            public bool CastingBoolean { get; set; }
+            public int CastingInteger { get; set; }
+        }
+
+        [Test]
+        public void test_cast_fails_to_incompatible_complex_type()
+        {
+            const string json = @"
+                {
+                    ""castingObject"": {
+                        ""caster"": ""true"",
+                        ""daster"": 99.99,
+                        ""faster"": false
+                    }
+                }";
+
+            dynamic config = new Config(json);
+            Assert.Throws<RuntimeBinderException>(() =>
+            {
+                CastingObject castingObject = config.castingObject;
+            });
+        }
     }
 }

--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.CSharp.RuntimeBinder;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace Centroid.Tests
 {
@@ -241,22 +242,28 @@ namespace Centroid.Tests
         }
 
         [Test]
-        public void test_cast_fails_to_incompatible_complex_type()
+        public void test_casts_array_of_object_to_complex_type()
         {
             const string json = @"
                 {
-                    ""castingObject"": {
-                        ""caster"": ""true"",
-                        ""daster"": 99.99,
-                        ""faster"": false
-                    }
+                    ""castingObjects"": [
+                        {
+                            ""castingString"": ""true"",
+                            ""castingBoolean"": true,
+                            ""castingInteger"": 42
+                        },
+                        {
+                            ""castingString"": ""clue"",
+                            ""castingBoolean"": false,
+                            ""castingInteger"": 84
+                        },
+                    ]
                 }";
 
             dynamic config = new Config(json);
-            Assert.Throws<RuntimeBinderException>(() =>
-            {
-                CastingObject castingObject = config.castingObject;
-            });
+            List<CastingObject> castingObjects = config.castingObjects;
+            Assert.That(castingObjects, Is.InstanceOf<List<CastingObject>>());
+            Assert.That(castingObjects.Count, Is.EqualTo(2));
         }
     }
 }

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -78,7 +78,23 @@ namespace Centroid
 
             try
             {
-                result = Convert.ChangeType(RawConfig, binder.Type);
+                JToken rawConfig = RawConfig;
+                result = rawConfig.ToObject(binder.Type);
+                //ensure at least one property in the config bound to the type
+                var JResult = JToken.FromObject(result);
+                bool hasBoundProperty =
+                    JResult.Any(property =>
+                    {
+                        var _property = (JProperty)property;
+                        return rawConfig.Any(rawProperty =>
+                        {
+                            var _rawProperty = (JProperty)rawProperty;
+                            return
+                                NormaliseKey(_rawProperty.Name).Equals(NormaliseKey(_property.Name))
+                                    && _rawProperty.Value.Equals(_property.Value);
+                        });
+                    });
+                if (!hasBoundProperty) throw new InvalidCastException();
                 return true;
             }
             catch (InvalidCastException)

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -80,19 +80,6 @@ namespace Centroid
             {
                 JToken rawConfig = RawConfig;
                 result = rawConfig.ToObject(binder.Type);
-                //ensure at least one property in the config bound to the type
-                var JResult = JToken.FromObject(result);
-                bool hasBoundProperty =
-                    JResult.Cast<JProperty>().Any(property =>
-                    {
-                        return rawConfig.Cast<JProperty>().Any(rawProperty =>
-                        {
-                            return
-                                NormaliseKey(rawProperty.Name).Equals(NormaliseKey(property.Name))
-                                    && rawProperty.Value.Equals(property.Value);
-                        });
-                    });
-                if (!hasBoundProperty) throw new InvalidCastException();
                 return true;
             }
             catch (InvalidCastException)

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -83,15 +83,13 @@ namespace Centroid
                 //ensure at least one property in the config bound to the type
                 var JResult = JToken.FromObject(result);
                 bool hasBoundProperty =
-                    JResult.Any(property =>
+                    JResult.Cast<JProperty>().Any(property =>
                     {
-                        var _property = (JProperty)property;
-                        return rawConfig.Any(rawProperty =>
+                        return rawConfig.Cast<JProperty>().Any(rawProperty =>
                         {
-                            var _rawProperty = (JProperty)rawProperty;
                             return
-                                NormaliseKey(_rawProperty.Name).Equals(NormaliseKey(_property.Name))
-                                    && _rawProperty.Value.Equals(_property.Value);
+                                NormaliseKey(rawProperty.Name).Equals(NormaliseKey(property.Name))
+                                    && rawProperty.Value.Equals(property.Value);
                         });
                     });
                 if (!hasBoundProperty) throw new InvalidCastException();


### PR DESCRIPTION
Implement Newtonsoft object conversion (`JToken.ToObject<T>`) in
`TryConvert` instead of utilizing CLR `Convert.ChangeType`.  This allows
the client using the `Config` object to simply bind to the desired type.

```cs
dynamic typedConfig = Config; //Config is of type Centroid.Config
MyCustomClass classPropertyValue = typedConfig.customClass;
//this will use JToken's inherent conversion techniques
```

Also added two Unit Tests to ensure casting functionality is functional.