### PR TITLE
Support for string indexing in .NET

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -215,5 +215,13 @@ namespace Centroid.Tests
             Assert.That(config.ContainsKey("theEnvironment"), Is.True);
             Assert.That(config.ContainsKey("DoesNotExist"), Is.False);
         }
+
+        [Test]
+        public void test_key_as_index()
+        {
+            dynamic config = new Config(JsonConfig);
+            var myString = "thekey";
+            Assert.That(config.theEnvironment[myString], Is.EqualTo("TheValue"));
+        }
     }
 }

--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.CSharp.RuntimeBinder;
@@ -168,9 +168,9 @@ namespace Centroid.Tests
                     }
                 }";
             dynamic config = new Config(json);
-            foreach (var kvp in config.Connections) 
+            foreach (var kvp in config.Connections)
             {
-                Assert.That(kvp.Value.Password, Is.EqualTo("secret")); 
+                Assert.That(kvp.Value.Password, Is.EqualTo("secret"));
             }
         }
 

--- a/dot-net/Centroid.sln.DotSettings
+++ b/dot-net/Centroid.sln.DotSettings
@@ -26,4 +26,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -35,6 +35,12 @@ namespace Centroid
             set { RawConfig[index] = value; }
         }
 
+        public object this[string index]
+        {
+            get { return GetValue(index); }
+            set { RawConfig[index] = value; }
+        }
+
         public bool ContainsKey(string key)
         {
             return GetActualKey(key) != null;

--- a/python/tests.py
+++ b/python/tests.py
@@ -133,3 +133,10 @@ class ConfigTest(unittest.TestCase):
         config = Config(self._json_config)
         self.assertTrue("the_environment" in config)
         self.assertTrue("does_not_exist" not in config)
+
+    def test_key_as_index(self):
+        config = Config(self._json_config)
+        my_string = "thekey"
+        self.assertEqual(config.the_environment[my_string], "TheValue")
+
+unittest.main()

--- a/python/tests.py
+++ b/python/tests.py
@@ -1,5 +1,6 @@
 import unittest
 import json
+import os.path
 from centroid import Config
 
 class ConfigTest(unittest.TestCase):
@@ -14,7 +15,7 @@ class ConfigTest(unittest.TestCase):
 
     @property
     def _shared_file_path(self):
-        return 'config.json'
+        return os.path.normpath('../config.json')
 
     def test_create_from_string(self):
         config = Config(self._json_config)

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -95,35 +95,6 @@ class ConfigTests < Test::Unit::TestCase
     assert_equal(config.shared, "production!")
   end
 
-  def test_all_environment_is_not_case_sensitive
-    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "All": {"Shared": "none", "AllOnly": "works"}}')
-    config = config.for_environment("Prod")
-    assert_equal(config.all_only, "works")
-
-    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "all": {"Shared": "none", "AllOnly": "works"}}')
-    config = config.for_environment("Prod")
-    assert_equal(config.all_only, "works")
-  end
-
-  def test_supports_deep_merge
-    config = Centroid::Config.new('{"Prod": {"Database": {"Server": "prod-sql"}}, "All": {"Database": {"MigrationsPath": "path/to/migrations"}}}')
-    config = config.for_environment("Prod")
-    assert_equal(config.database.server, "prod-sql")
-    assert_equal(config.database.migrations_path, "path/to/migrations")
-  end
-
-  def test_has_key
-    config = Centroid::Config.new(json_config)
-    assert(config.has_key?("the_environment"))
-    assert(!config.has_key?("does_not_exist"))
-  end
-
-  def test_respond_to
-    config = Centroid::Config.new(json_config)
-    assert(config.respond_to?(:the_environment))
-    assert(!config.respond_to?(:does_not_exist))
-  end
-
   def test_indexing_json_array
     config = Centroid::Config.new(json_config_with_array)
     assert_equal(config.the_array[0].the_key, "Value1")
@@ -169,4 +140,34 @@ class ConfigTests < Test::Unit::TestCase
         assert_equal(v.password, "secret")
       end
   end
+
+  def test_all_environment_is_not_case_sensitive
+    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "All": {"Shared": "none", "AllOnly": "works"}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.all_only, "works")
+
+    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "all": {"Shared": "none", "AllOnly": "works"}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.all_only, "works")
+  end
+
+  def test_supports_deep_merge
+    config = Centroid::Config.new('{"Prod": {"Database": {"Server": "prod-sql"}}, "All": {"Database": {"MigrationsPath": "path/to/migrations"}}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.database.server, "prod-sql")
+    assert_equal(config.database.migrations_path, "path/to/migrations")
+  end
+
+  def test_has_key
+    config = Centroid::Config.new(json_config)
+    assert(config.has_key?("the_environment"))
+    assert(!config.has_key?("does_not_exist"))
+  end
+
+  def test_respond_to
+    config = Centroid::Config.new(json_config)
+    assert(config.respond_to?(:the_environment))
+    assert(!config.respond_to?(:does_not_exist))
+  end
+
 end

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -164,6 +164,12 @@ class ConfigTests < Test::Unit::TestCase
     assert(!config.has_key?("does_not_exist"))
   end
 
+  def test_key_as_index
+    config = Centroid::Config.new(json_config)
+    my_string = "thekey"
+    assert_equal(config.the_environment[my_string], "TheValue")
+  end
+
   def test_respond_to
     config = Centroid::Config.new(json_config)
     assert(config.respond_to?(:the_environment))

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -12,7 +12,7 @@ class ConfigTests < Test::Unit::TestCase
   end
 
   def shared_file_path
-    'config.json'
+    File.join('..','..','config.json')
   end
 
   def test_create_from_string


### PR DESCRIPTION
Hopefully just branching instead of forking and branching is not too egregious a faux pas to cause any sort of heart burn.

These changes are intended to give me the capability to dynamically reference a `dynamic` key value in C#. As far as I can tell, key paths can only be 'hardcoded'. In other words, you must type out the hierarchy separating each level with a `.` (e.g. `prod.task.task2` [see config.json below for reference]). Other than looping through everything, I wasn't able to see a way dynamically reference a specific key.

Ultimately I want to be able to reference keys of the same name as whichever derived class happens to be implementing the base class at run time. Here's a bit of code to make things a little more clear.
```
  public class Task2 : BaseExecutable
  {
    var value = GetParameter<string>("param2");
    ...
  }
```
```
  public abstract class BaseExecutable
  {
    protected T GetParameter<T>(string key)
    {
      var taskString = GetType().Name;
      dynamic container = prod.task[taskString];
      dynamic paramValue = currentTask[key];
      var typeConverter = TypeDescriptor.GetConverter(typeof(T));
      return (T)typeConverter.ConvertFrom(paramValue);
    }
  }
```
  
  
Example config.json:
```
{
  "Prod": {
    "task": {
      "task1": {
        "param1": "val1",
        "param2": "val2",
        "param3": "val3"
      },
      "task2": {
        "param1": "val1",
        "param2": "val2"
      },
      "task3": {
        "param1": "val1",
        "param2": "val2",
        "param3": "val3",
        "param4": "val4"
      }
    }
  },
  "All": {
    "CI": {
      "Server": "centroid-ci01.centroid.local",
      "Repo": "https://github.com/ResourceDataInc/Centroid"
    }
  }
}
```  
  
  
On a side note, I found that there is one more unit test for Ruby than there are for python or .NET. Being a Ruby dolt and not having any time to do any digging, I did not attempt to understand exactly what it did or create complementary tests in python or .NET. The test is `test_respond_to`.