### PR TITLE
Support for indexing via Key

### DIFF
--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -215,5 +215,13 @@ namespace Centroid.Tests
             Assert.That(config.ContainsKey("theEnvironment"), Is.True);
             Assert.That(config.ContainsKey("DoesNotExist"), Is.False);
         }
+
+        [Test]
+        public void test_key_as_index()
+        {
+            dynamic config = new Config(JsonConfig);
+            var myString = "thekey";
+            Assert.That(config.theEnvironment[myString], Is.EqualTo("TheValue"));
+        }
     }
 }

--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -187,7 +187,7 @@ namespace Centroid.Tests
         }
 
         [Test]
-        public void supports_deep_merge()
+        public void test_supports_deep_merge()
         {
             const string json = @"
                 {
@@ -206,6 +206,41 @@ namespace Centroid.Tests
             dynamic config = new Config(json).ForEnvironment("Dev");
             Assert.That(config.Database.Server, Is.EqualTo("the-dev-database"));
             Assert.That(config.Database.MigrationsPath, Is.EqualTo("path/to/migrations"));
+        }
+
+        [Test]
+        public void test_supports_merge_override()
+        {
+            const string json = @"
+                {
+                    ""Dev"": {
+                        ""Connection"": {
+                            ""server"": ""dev-server"",
+                            ""database"": ""dev_database"",
+                            ""SdeConnectionFile"": ""DEV:sde(file)""
+                        }
+                    },
+                    ""All"": {
+                        ""Connection"": {
+                            ""server"": """",
+                            ""database"": """",
+                            ""instance"": """",
+                            ""user"": ""default-user"",
+                            ""password"": ""default-password"",
+                            ""version"": """",
+                            ""SdeConnectionFile"": """"
+                        }
+                    }
+                }";
+
+            dynamic config = new Config(json).ForEnvironment("Dev");
+            Assert.That(config.Connection.Server, Is.EqualTo("dev-server"));
+            Assert.That(config.Connection.database, Is.EqualTo("dev_database"));
+            Assert.That(config.Connection.instance, Is.EqualTo(""));
+            Assert.That(config.Connection.user, Is.EqualTo("default-user"));
+            Assert.That(config.Connection.password, Is.EqualTo("default-password"));
+            Assert.That(config.Connection.version, Is.EqualTo(""));
+            Assert.That(config.Connection.SdeConnectionFile, Is.EqualTo("DEV:sde(file)"));
         }
 
         [Test]

--- a/dot-net/Centroid.Tests/ConfigTest.cs
+++ b/dot-net/Centroid.Tests/ConfigTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.CSharp.RuntimeBinder;
@@ -168,9 +168,9 @@ namespace Centroid.Tests
                     }
                 }";
             dynamic config = new Config(json);
-            foreach (var kvp in config.Connections) 
+            foreach (var kvp in config.Connections)
             {
-                Assert.That(kvp.Value.Password, Is.EqualTo("secret")); 
+                Assert.That(kvp.Value.Password, Is.EqualTo("secret"));
             }
         }
 

--- a/dot-net/Centroid.sln.DotSettings
+++ b/dot-net/Centroid.sln.DotSettings
@@ -26,4 +26,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -29,13 +29,13 @@ namespace Centroid
 
         public dynamic RawConfig { get; set; }
 
-        public object this[int index]
+        public dynamic this[int index]
         {
             get { return GetValue(index); }
             set { RawConfig[index] = value; }
         }
 
-        public object this[string index]
+        public dynamic this[string index]
         {
             get { return GetValue(index); }
             set { RawConfig[index] = value; }

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -117,12 +117,12 @@ namespace Centroid
             return container.Properties().Select(p => p.Name);
         }
 
-        static string NormaliseKey(string key)
+        private static string NormaliseKey(string key)
         {
             return key.Replace("_", String.Empty).ToLower();
         }
 
-        static dynamic GetValueFromContainer(dynamic container)
+        private static dynamic GetValueFromContainer(dynamic container)
         {
             if (container is JContainer)
             {
@@ -131,30 +131,30 @@ namespace Centroid
             return container.Value;
         }
 
-        dynamic GetValue(int index)
+        private dynamic GetValue(int index)
         {
             var container = RawConfig[index];
             return GetValueFromContainer(container);
         }
 
-        dynamic GetValue(string key)
+        private dynamic GetValue(string key)
         {
             var container = GetContainer(key);
             return GetValueFromContainer(container);
         }
 
-        dynamic GetContainer(string key)
+        private dynamic GetContainer(string key)
         {
             var actualKey = GetActualKey(key);
             return actualKey == null ? null : RawConfig[actualKey];
         }
 
-        string GetActualKey(string key)
+        private string GetActualKey(string key)
         {
             return GetDynamicMemberNames().SingleOrDefault(m => NormaliseKey(m) == NormaliseKey(key));
         }
 
-        void ValidateUniqueKeys()
+        private void ValidateUniqueKeys()
         {
             var normalizedKeys = GetDynamicMemberNames().Select(p => new { Key = p, NormalizedKey = NormaliseKey(p) });
             var duplicates = normalizedKeys.GroupBy(nk => nk.NormalizedKey).Where(g => g.Count() > 1).ToArray();
@@ -165,7 +165,7 @@ namespace Centroid
             throw new InvalidOperationException("Centroid.Config instance contains duplicate keys: " + string.Join(", ", keys));
         }
 
-        static void MergeInto(JContainer left, JToken right)
+        private static void MergeInto(JContainer left, JToken right)
         {
             foreach (var rightChild in right.Children<JProperty>())
             {

--- a/dot-net/Centroid/Config.cs
+++ b/dot-net/Centroid/Config.cs
@@ -35,6 +35,12 @@ namespace Centroid
             set { RawConfig[index] = value; }
         }
 
+        public object this[string index]
+        {
+            get { return GetValue(index); }
+            set { RawConfig[index] = value; }
+        }
+
         public bool ContainsKey(string key)
         {
             return GetActualKey(key) != null;

--- a/python/tests.py
+++ b/python/tests.py
@@ -128,6 +128,39 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.database.server, "prod-sql")
         self.assertEqual(config.database.migrations_path, "path/to/migrations")
 
+    def test_supports_merge_override(self):
+        json = """
+        {
+            "Dev": {
+                "Connection": {
+                    "server": "dev-server",
+                    "database": "dev_database",
+                    "SdeConnectionFile": "DEV:sde(file)"
+                }
+            },
+            "All": {
+                "Connection": {
+                    "server": "",
+                    "database": "",
+                    "instance": "",
+                    "user": "default-user",
+                    "password": "default-password",
+                    "version": "",
+                    "SdeConnectionFile": ""
+                }
+            }
+        }"""
+
+        config = Config(json)
+        config = config.for_environment("Dev")
+        self.assertEqual(config.Connection.Server, "dev-server")
+        self.assertEqual(config.Connection.database, "dev_database")
+        self.assertEqual(config.Connection.instance, "")
+        self.assertEqual(config.Connection.user, "default-user")
+        self.assertEqual(config.Connection.password, "default-password")
+        self.assertEqual(config.Connection.version, "")
+        self.assertEqual(config.Connection.SdeConnectionFile, "DEV:sde(file)")
+
     def test_has_key(self):
         config = Config(self._json_config)
         self.assertTrue("the_environment" in config)

--- a/python/tests.py
+++ b/python/tests.py
@@ -132,3 +132,9 @@ class ConfigTest(unittest.TestCase):
         config = Config(self._json_config)
         self.assertTrue("the_environment" in config)
         self.assertTrue("does_not_exist" not in config)
+
+    def test_key_as_index(self):
+        config = Config(self._json_config)
+        my_string = "thekey"
+        self.assertEqual(config.the_environment[my_string], "TheValue")
+

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -95,35 +95,6 @@ class ConfigTests < Test::Unit::TestCase
     assert_equal(config.shared, "production!")
   end
 
-  def test_all_environment_is_not_case_sensitive
-    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "All": {"Shared": "none", "AllOnly": "works"}}')
-    config = config.for_environment("Prod")
-    assert_equal(config.all_only, "works")
-
-    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "all": {"Shared": "none", "AllOnly": "works"}}')
-    config = config.for_environment("Prod")
-    assert_equal(config.all_only, "works")
-  end
-
-  def test_supports_deep_merge
-    config = Centroid::Config.new('{"Prod": {"Database": {"Server": "prod-sql"}}, "All": {"Database": {"MigrationsPath": "path/to/migrations"}}}')
-    config = config.for_environment("Prod")
-    assert_equal(config.database.server, "prod-sql")
-    assert_equal(config.database.migrations_path, "path/to/migrations")
-  end
-
-  def test_has_key
-    config = Centroid::Config.new(json_config)
-    assert(config.has_key?("the_environment"))
-    assert(!config.has_key?("does_not_exist"))
-  end
-
-  def test_respond_to
-    config = Centroid::Config.new(json_config)
-    assert(config.respond_to?(:the_environment))
-    assert(!config.respond_to?(:does_not_exist))
-  end
-
   def test_indexing_json_array
     config = Centroid::Config.new(json_config_with_array)
     assert_equal(config.the_array[0].the_key, "Value1")
@@ -169,4 +140,34 @@ class ConfigTests < Test::Unit::TestCase
         assert_equal(v.password, "secret")
       end
   end
+
+  def test_all_environment_is_not_case_sensitive
+    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "All": {"Shared": "none", "AllOnly": "works"}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.all_only, "works")
+
+    config = Centroid::Config.new('{"Prod": {"Shared": "production!"}, "all": {"Shared": "none", "AllOnly": "works"}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.all_only, "works")
+  end
+
+  def test_supports_deep_merge
+    config = Centroid::Config.new('{"Prod": {"Database": {"Server": "prod-sql"}}, "All": {"Database": {"MigrationsPath": "path/to/migrations"}}}')
+    config = config.for_environment("Prod")
+    assert_equal(config.database.server, "prod-sql")
+    assert_equal(config.database.migrations_path, "path/to/migrations")
+  end
+
+  def test_has_key
+    config = Centroid::Config.new(json_config)
+    assert(config.has_key?("the_environment"))
+    assert(!config.has_key?("does_not_exist"))
+  end
+
+  def test_respond_to
+    config = Centroid::Config.new(json_config)
+    assert(config.respond_to?(:the_environment))
+    assert(!config.respond_to?(:does_not_exist))
+  end
+
 end

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -158,6 +158,40 @@ class ConfigTests < Test::Unit::TestCase
     assert_equal(config.database.migrations_path, "path/to/migrations")
   end
 
+  def test_supports_merge_override()
+    json = '
+    {
+      "Dev": {
+        "Connection": {
+          "server": "dev-server",
+          "database": "dev_database",
+          "SdeConnectionFile": "DEV:sde(file)"
+        }
+      },
+      "All": {
+        "Connection": {
+          "server": "",
+          "database": "",
+          "instance": "",
+          "user": "default-user",
+          "password": "default-password",
+          "version": "",
+          "SdeConnectionFile": ""
+        }
+      }
+    }'
+
+    config = Centroid::Config.new(json)
+    config = config.for_environment("Dev");
+    assert_equal(config.Connection.Server, "dev-server");
+    assert_equal(config.Connection.database, "dev_database");
+    assert_equal(config.Connection.instance, "");
+    assert_equal(config.Connection.user, "default-user");
+    assert_equal(config.Connection.password, "default-password");
+    assert_equal(config.Connection.version, "");
+    assert_equal(config.Connection.SdeConnectionFile, "DEV:sde(file)");
+  end
+
   def test_has_key
     config = Centroid::Config.new(json_config)
     assert(config.has_key?("the_environment"))

--- a/ruby/test/centroid_test.rb
+++ b/ruby/test/centroid_test.rb
@@ -164,6 +164,12 @@ class ConfigTests < Test::Unit::TestCase
     assert(!config.has_key?("does_not_exist"))
   end
 
+  def test_key_as_index
+    config = Centroid::Config.new(json_config)
+    my_string = "thekey"
+    assert_equal(config.the_environment[my_string], "TheValue")
+  end
+
   def test_respond_to
     config = Centroid::Config.new(json_config)
     assert(config.respond_to?(:the_environment))


### PR DESCRIPTION
Take 2 on [PR 69](https://github.com/ResourceDataInc/Centroid/pull/69)

In short this enables C# to generate key names and reference them dynamically.

Before, the key had to be hardcoded, e.g. `config.task.task1.param1`. With this change you can do something like:
```
foreach (var ii in new[] {"task1", "task2", "task3"})
{
   Console.WriteLine("Value for {0}.param1 is {1}", ii, config.task[ii].param1);
}
```